### PR TITLE
Fix a bug when deleting an event.

### DIFF
--- a/PredictionIO/Source/PredictionIO.swift
+++ b/PredictionIO/Source/PredictionIO.swift
@@ -221,7 +221,7 @@ public class EventClient: BaseClient {
     public func deleteEvent(eventID: String, completionHandler: @escaping (Error?) -> Void) {
         do {
             let url = try eventURL(for: eventID)
-            networkConnection.get(url: url, queryParams: queryParams) { result in
+            networkConnection.delete(url: url, queryParams: queryParams) { result in
                 if let error = result.error {
                     completionHandler(error)
                 } else {

--- a/PredictionIO/Tests/EventClientTests.swift
+++ b/PredictionIO/Tests/EventClientTests.swift
@@ -101,11 +101,16 @@ class EventClientTests: XCTestCase {
         let event = Event(event: "register", entityType: "user", entityID: "foo")
         let eventID = createEvent(event)
 
-        let deleteEventExpectation = self.expectation(description: "Deleting an event")
+        let testDoneExpectation = self.expectation(description: "Deleting an event")
         eventClient.deleteEvent(eventID: eventID) { error in
             XCTAssertNil(error, "Request should succeed, got \(error!)")
 
-            deleteEventExpectation.fulfill()
+            // Verify that the event no longer exists.
+            self.eventClient.getEvent(eventID: eventID) { result in
+                XCTAssertTrue(result.isFailure)
+
+                testDoneExpectation.fulfill()
+            }
         }
 
         waitForExpectations(timeout: 5)


### PR DESCRIPTION
Call HTTP DELETE instead of GET.